### PR TITLE
✨ The previous directory is now open

### DIFF
--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -37,6 +37,19 @@ struct ContentView: View {
             .background(Color.black.opacity(0.3))
         }
         .padding(.all, 16)
+        .onAppear {
+            if let data = UserDefaults.standard.data(forKey: "user_selected_dir") {
+                var stale = false
+                if let url = try? URL(resolvingBookmarkData: data,
+                                            options: [.withSecurityScope],
+                                            bookmarkDataIsStale: &stale),
+                   url.startAccessingSecurityScopedResource() {
+                    self.items = load(path: url)
+                    self.inputDir = url.relativePath
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+        }
     }
 
     private func openPanel() {


### PR DESCRIPTION
This pull request adds functionality to `ContentView` in the `QuickShelf` project to automatically load user-selected directories from `UserDefaults` when the view appears. This ensures a smoother user experience by restoring the previous state.

#5 

Key change:

* [`QuickShelf/ContentView.swift`](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efR40-R52): Added an `onAppear` modifier to check for a saved directory in `UserDefaults`, resolve its bookmark data, and load items from the directory if accessible.