### PR TITLE
Modified the icons displayed in the list to be the same as in the Finder

### DIFF
--- a/QuickShelf/Extensions/ProcessInfo+Preview.swift
+++ b/QuickShelf/Extensions/ProcessInfo+Preview.swift
@@ -1,0 +1,14 @@
+//
+//  ProcessInfo+Preview.swift
+//  QuickShelf
+//
+//  Created by slowhand on 2025/07/15.
+//
+
+import SwiftUI
+
+extension ProcessInfo {
+    static var isPreview: Bool {
+        processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] == "1"
+    }
+}

--- a/QuickShelf/Views/ShelfItemView.swift
+++ b/QuickShelf/Views/ShelfItemView.swift
@@ -12,10 +12,18 @@ struct ShelfItemView: View {
 
     var body: some View {
         HStack {
-            if item.isDirectory {
-                Image(systemName: "folder")
+            if ProcessInfo.isPreview {
+                // Dummy image for preview
+                if item.isDirectory {
+                    Image(systemName: "folder")
+                } else {
+                    Image(systemName: "text.page")
+                }
             } else {
-                Image(systemName: "text.page")
+                Image(nsImage: NSWorkspace.shared.icon(forFile: item.url.path))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 20, height: 20)
             }
             Text(item.url.lastPathComponent)
         }


### PR DESCRIPTION
This pull request introduces a new utility for detecting SwiftUI preview mode and updates the `ShelfItemView` to display a placeholder icon during previews. These changes improve the development experience by ensuring the view renders properly in Xcode previews without relying on actual file system resources.

#11 

### New utility for SwiftUI preview detection:
* Added a `ProcessInfo+Preview.swift` file containing an extension to `ProcessInfo` with a static property `isPreview`, which checks if the app is running in Xcode preview mode. (`[QuickShelf/Extensions/ProcessInfo+Preview.swiftR1-R14](diffhunk://#diff-82afd1bee23b4217b0d4e4fa7ee5b0b166b2d7c5bf3b79e4096c0849e38e5ce4R1-R14)`)

### Updates to `ShelfItemView` for preview compatibility:
* Updated the `ShelfItemView` to conditionally display a dummy system icon (`folder` or `text.page`) when in preview mode, and the actual file icon otherwise. (`[QuickShelf/Views/ShelfItemView.swiftR15-R27](diffhunk://#diff-d31706f20337c2436e5499efda0dd2abffe37527ac0a89f27c43d0aa79c59f1cR15-R27)`)