### PR TITLE
🔧 Hide preferences menu item from context menu

### DIFF
--- a/QuickShelf/QuickShelfApp.swift
+++ b/QuickShelf/QuickShelfApp.swift
@@ -49,8 +49,8 @@ struct QuickShelfApp: App {
 
     private func popupContextMenu(for item: NSStatusItem) {
         let menu = NSMenu()
-        menu.addItem(withTitle: "Preferences…", action: nil, keyEquivalent: ",")
-        menu.addItem(.separator())
+//        menu.addItem(withTitle: "Preferences…", action: nil, keyEquivalent: ",")
+//        menu.addItem(.separator())
         menu.addItem(withTitle: "Quit", action: #selector(NSApp.terminate(_:)), keyEquivalent: "q")
         item.menu = menu
         item.button?.performClick(nil)


### PR DESCRIPTION
This pull request includes a minor change to the `QuickShelfApp.swift` file. The change comments out two menu items in the `popupContextMenu` function, leaving only the "Quit" option in the context menu.

* [`QuickShelf/QuickShelfApp.swift`](diffhunk://#diff-f311c24a3978bb112c9c000bd13b2e7a19645724869290e2d5c0c0306648c251L52-R53): Commented out the "Preferences…" menu item and a separator in the `popupContextMenu` function, simplifying the menu to include only the "Quit" option.