### PR TITLE
🔧 Changed hotkey modifier key from Cmd+Option to Cmd+Control

### DIFF
--- a/QuickShelf/QuickShelfApp.swift
+++ b/QuickShelf/QuickShelfApp.swift
@@ -15,7 +15,7 @@ struct QuickShelfApp: App {
     @State private var statusItem: NSStatusItem?
 
     private let hotKey = HotKey(key: .s,
-                                modifiers: [.command, .option])
+                                modifiers: [.command, .control])
 
     var body: some Scene {
         MenuBarExtra {


### PR DESCRIPTION
This pull request includes a minor update to the `QuickShelfApp` in `QuickShelf/QuickShelfApp.swift`. The change modifies the keyboard shortcut for the `hotKey` by replacing the `.option` modifier with `.control` for improved usability.