### PR TITLE
💚 Added universal binary build support in GitHub Actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -29,6 +29,8 @@ jobs:
                    -config Release \
                    -archivePath build/QuickShelf.xcarchive \
                    clean archive \
+                   ARCHS="arm64 x86_64" \
+                   ONLY_ACTIVE_ARCH=NO \
                    CODE_SIGN_IDENTITY="" \
                    CODE_SIGNING_REQUIRED="NO"
       env:


### PR DESCRIPTION
This pull request updates the `create-release.yml` workflow file to improve compatibility and ensure proper builds for multiple architectures.

### Workflow configuration updates:

* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79R32-R33): Added `ARCHS="arm64 x86_64"` and `ONLY_ACTIVE_ARCH=NO` to the `xcodebuild` command in the `jobs:` section to enable building for both arm64 and x86_64 architectures, and to ensure all architectures are included regardless of the active one.