### PR TITLE
🔧 ShelfItem is now Transferable-compatible and drag-and-drop function…

### DIFF
--- a/QuickShelf.xcodeproj/project.pbxproj
+++ b/QuickShelf.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.0.5;
+				MARKETING_VERSION = 0.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.slowlab.QuickShelf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -448,7 +448,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.0.5;
+				MARKETING_VERSION = 0.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.slowlab.QuickShelf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -29,7 +29,7 @@ struct ContentView: View {
                     ShelfItemView(item: item)
                         .alignmentGuide(.listRowSeparatorLeading) { _ in  0 }
                         .listRowSeparatorTint(Color.white.opacity(0.3))
-                        .draggable(item.url)
+                        .draggable(item)
                 }
             }
             .frame(height: 300)

--- a/QuickShelf/Models/ShelfItem.swift
+++ b/QuickShelf/Models/ShelfItem.swift
@@ -6,8 +6,9 @@
 //
 
 import Foundation
+import CoreTransferable
 
-final class ShelfItem: Hashable {
+final class ShelfItem: Hashable, Transferable {
     static func == (lhs: ShelfItem, rhs: ShelfItem) -> Bool {
         return lhs.url == rhs.url
     }
@@ -22,5 +23,15 @@ final class ShelfItem: Hashable {
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(url)
+    }
+    
+    static var transferRepresentation: some TransferRepresentation {
+        FileRepresentation(contentType: .item) { item in
+            SentTransferredFile(item.url)
+        } importing: { received in
+            ShelfItem(url: received.file,
+                      isDirectory: received.file.hasDirectoryPath)
+        }
+        ProxyRepresentation(exporting: \.url)
     }
 }


### PR DESCRIPTION
This pull request introduces updates to the `QuickShelf` project, including a version bump, enhancements to the `ShelfItem` model, and changes to improve item dragging functionality. The most important changes are grouped below:

### Versioning Updates:
* Updated the `MARKETING_VERSION` in `QuickShelf.xcodeproj/project.pbxproj` from `0.0.5` to `0.0.6`, reflecting a new version release. [[1]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caL422-R422) [[2]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caL451-R451)

### Feature Enhancements:
* Made `ShelfItem` conform to the `Transferable` protocol by adding a `transferRepresentation` property, enabling support for file transfer functionality. [[1]](diffhunk://#diff-5685a7cca0697bb8d22128b89e9089e54818ea6c5c01aaebd9a53659ba614b74R9-R11) [[2]](diffhunk://#diff-5685a7cca0697bb8d22128b89e9089e54818ea6c5c01aaebd9a53659ba614b74R27-R36)

### Drag-and-Drop Improvements:
* Updated the `.draggable` modifier in `ContentView.swift` to pass the entire `ShelfItem` object instead of just its URL, improving drag-and-drop behavior.…ality is implemented, updated to version 0.0.6