### PR TITLE
🔧 Updated version to 0.0.7 and fixed security scope resource access

### DIFF
--- a/QuickShelf.xcodeproj/project.pbxproj
+++ b/QuickShelf.xcodeproj/project.pbxproj
@@ -419,7 +419,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.0.6;
+				MARKETING_VERSION = 0.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.slowlab.QuickShelf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -448,7 +448,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.0.6;
+				MARKETING_VERSION = 0.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.slowlab.QuickShelf;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/QuickShelf/Models/ShelfItem.swift
+++ b/QuickShelf/Models/ShelfItem.swift
@@ -27,7 +27,11 @@ final class ShelfItem: Hashable, Transferable {
     
     static var transferRepresentation: some TransferRepresentation {
         FileRepresentation(contentType: .item) { item in
-            SentTransferredFile(item.url)
+            let accessed = item.url.startAccessingSecurityScopedResource()
+            defer {
+                if accessed { item.url.stopAccessingSecurityScopedResource() }
+            }
+            return SentTransferredFile(item.url)
         } importing: { received in
             ShelfItem(url: received.file,
                       isDirectory: received.file.hasDirectoryPath)


### PR DESCRIPTION
This pull request includes a version update for the `QuickShelf` project and an improvement to the `ShelfItem` model to ensure proper resource handling during file transfers.

### Version Update:
* Updated the `MARKETING_VERSION` from `0.0.6` to `0.0.7` in the `QuickShelf.xcodeproj/project.pbxproj` file. This reflects a new release of the project. [[1]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caL422-R422) [[2]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caL451-R451)

### Resource Handling Improvement:
* Modified the `ShelfItem` model in `QuickShelf/Models/ShelfItem.swift` to use `startAccessingSecurityScopedResource` and `stopAccessingSecurityScopedResource` for safely accessing security-scoped resources during file transfers. This ensures proper cleanup of resource access.