### PR TITLE
🔧 Implement About view

### DIFF
--- a/QuickShelf/Extensions/Bundle+Info.swift
+++ b/QuickShelf/Extensions/Bundle+Info.swift
@@ -1,0 +1,24 @@
+//
+//  Bundle+Info.swift
+//  QuickShelf
+//
+//  Created by slowhand on 2025/08/02.
+//
+
+import Foundation
+
+extension Bundle {
+    var displayName: String {
+        object(forInfoDictionaryKey: "CFBundleDisplayName")
+            as? String ??
+        object(forInfoDictionaryKey: "CFBundleName")
+            as? String ??
+        "QuickShelf"
+    }
+
+    var fullVersion: String {
+        let version = object(forInfoDictionaryKey: "CFBundleShortVersionString")
+            as? String ?? "-"
+        return "\(version)"
+    }
+}

--- a/QuickShelf/Views/Settings/AboutView.swift
+++ b/QuickShelf/Views/Settings/AboutView.swift
@@ -6,11 +6,37 @@
 //
 
 import SwiftUI
+import AppKit
 
 struct AboutView: View {
+    private let icon = NSApplication.shared.applicationIconImage
+
     var body: some View {
-        Text("About")
-            .padding(20)
+        HStack(alignment: .top, spacing: 24) {
+            Image(nsImage: icon!)
+                 .resizable()
+                 .aspectRatio(contentMode: .fit)
+                 .frame(width: 96, height: 96)
+                 .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                 .shadow(radius: 6)
+
+             VStack(alignment: .leading, spacing: 6) {
+                 Text(Bundle.main.displayName)
+                     .font(.title)
+                     .fontWeight(.semibold)
+
+                 Text("Version \(Bundle.main.fullVersion)")
+                     .font(.subheadline)
+                     .foregroundStyle(.secondary)
+
+                 Text("© \(String(Calendar.current.component(.year, from: Date()))) SlowLab. All rights reserved.")
+                     .font(.footnote)
+                     .foregroundStyle(.secondary)
+             }
+             Spacer()
+         }
+         .padding(32)
+         .frame(minWidth: 420, minHeight: 180)
     }
 }
 


### PR DESCRIPTION
This pull request introduces enhancements to the `QuickShelf` app by adding utility extensions to the `Bundle` class for retrieving app metadata and updating the `AboutView` to display a more detailed and visually appealing layout. These changes improve code reuse and enhance the user interface.

Issue:
#37 

### Enhancements to app metadata retrieval:

* [`QuickShelf/Extensions/Bundle+Info.swift`](diffhunk://#diff-b63b2fd2c899ebdb4c2db38f92f593ca79722cba8a2fa578c4e449b9ebb75956R1-R24): Added a `Bundle` extension with `displayName` and `fullVersion` properties to fetch the app's display name and version information, providing fallback values if the keys are not found.

### Improvements to the `AboutView`:

* `QuickShelf/Views/Settings/AboutView.swift`: Updated the `AboutView` to display the app icon, name, version, and copyright information in a structured layout. This includes:
  - Adding an app icon using `NSApplication.shared.applicationIconImage`.
  - Displaying the app's display name and version using the new `Bundle` extension properties.
  - Enhancing the layout with SwiftUI components like `HStack`, `VStack`, and styled `Text` elements.