### PR TITLE
🔧 Implement centralized security-scoped resource management with prop…

### DIFF
--- a/QuickShelf/Models/SecurityScope.swift
+++ b/QuickShelf/Models/SecurityScope.swift
@@ -1,0 +1,29 @@
+//
+//  SecurityScope.swift
+//  QuickShelf
+//
+//  Created by slowhand on 2025/08/02.
+//
+
+import Foundation
+
+final class SecurityScope {
+    static let shared = SecurityScope()
+    private var scopedUrl: URL?
+
+    func beginAccess(for url: URL) -> Bool {
+        if let url = scopedUrl {
+            url.stopAccessingSecurityScopedResource()
+        }
+        if url.startAccessingSecurityScopedResource() {
+            scopedUrl = url
+            return true
+        }
+        return false
+    }
+
+    func endAccess() {
+        scopedUrl?.stopAccessingSecurityScopedResource()
+        scopedUrl = nil
+    }
+}

--- a/QuickShelf/QuickShelfApp.swift
+++ b/QuickShelf/QuickShelfApp.swift
@@ -62,7 +62,13 @@ struct QuickShelfApp: App {
         settingsItem.target = AppDelegate.shared
         menu.addItem(settingsItem)
         menu.addItem(.separator())
-        menu.addItem(withTitle: "Quit", action: #selector(NSApp.terminate(_:)), keyEquivalent: "q")
+        let quitItem = NSMenuItem(
+            title: "Quit",
+            action: #selector(AppDelegate.terminate(_:)),
+            keyEquivalent: "q"
+        )
+        quitItem.target = AppDelegate.shared
+        menu.addItem(quitItem)
         item.menu = menu
         item.button?.performClick(nil)
         item.menu = nil
@@ -75,5 +81,10 @@ class AppDelegate: NSObject {
 
     @objc func openPreferences(_ sender: Any?) {
         openSettings?()
+    }
+
+    @objc func terminate(_ sender: Any?) {
+        SecurityScope.shared.endAccess()
+        NSApp.terminate(sender)
     }
 }


### PR DESCRIPTION
This pull request introduces a new `SecurityScope` utility to manage security-scoped resource access, refactors related code in `ContentView`, and updates the app's quit behavior to ensure proper resource cleanup. These changes improve resource management and maintainability.

### Security-scoped resource management:

* Added a new `SecurityScope` class in `QuickShelf/Models/SecurityScope.swift` to centralize and manage security-scoped resource access. It provides methods to begin and end access for a URL, ensuring proper cleanup of resources.
* Updated `ContentView` in `QuickShelf/ContentView.swift` to use `SecurityScope.shared.beginAccess(for:)` instead of directly calling `startAccessingSecurityScopedResource()` and `stopAccessingSecurityScopedResource()`. This simplifies and standardizes resource access logic. [[1]](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efL46-L49) [[2]](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efL64-R71)

### Application lifecycle improvements:

* Modified the "Quit" menu item in `QuickShelfApp.swift` to call a new `terminate(_:)` method in `AppDelegate` instead of directly invoking `NSApp.terminate(_)`. This ensures that `SecurityScope.shared.endAccess()` is called before the app terminates, releasing any active security-scoped resources. [[1]](diffhunk://#diff-f311c24a3978bb112c9c000bd13b2e7a19645724869290e2d5c0c0306648c251L65-R71) [[2]](diffhunk://#diff-f311c24a3978bb112c9c000bd13b2e7a19645724869290e2d5c0c0306648c251R85-R89)…er cleanup