### PR TITLE
Add LaunchAtLogin toggle to GeneralView settings

### DIFF
--- a/QuickShelf.xcodeproj/project.pbxproj
+++ b/QuickShelf.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B31AE332E43FF0600C4653D /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = 6B31AE322E43FF0600C4653D /* LaunchAtLogin */; };
 		6B3437242E3B6B4F00C52D3C /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = 6B3437232E3B6B4F00C52D3C /* KeyboardShortcuts */; };
 		6B400A802E174A6E00505989 /* MenuBarExtraAccess in Frameworks */ = {isa = PBXBuildFile; productRef = 6B400A7F2E174A6E00505989 /* MenuBarExtraAccess */; };
 /* End PBXBuildFile section */
@@ -57,6 +58,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6B31AE332E43FF0600C4653D /* LaunchAtLogin in Frameworks */,
 				6B400A802E174A6E00505989 /* MenuBarExtraAccess in Frameworks */,
 				6B3437242E3B6B4F00C52D3C /* KeyboardShortcuts in Frameworks */,
 			);
@@ -121,6 +123,7 @@
 			packageProductDependencies = (
 				6B400A7F2E174A6E00505989 /* MenuBarExtraAccess */,
 				6B3437232E3B6B4F00C52D3C /* KeyboardShortcuts */,
+				6B31AE322E43FF0600C4653D /* LaunchAtLogin */,
 			);
 			productName = QuickShelf;
 			productReference = 6B400A532E1749FB00505989 /* QuickShelf.app */;
@@ -207,6 +210,7 @@
 			packageReferences = (
 				6B400A7E2E174A6E00505989 /* XCRemoteSwiftPackageReference "MenuBarExtraAccess" */,
 				6B3437222E3B6B4F00C52D3C /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */,
+				6B31AE312E43FF0600C4653D /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 6B400A542E1749FB00505989 /* Products */;
@@ -564,6 +568,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		6B31AE312E43FF0600C4653D /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sindresorhus/LaunchAtLogin-Modern";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
 		6B3437222E3B6B4F00C52D3C /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sindresorhus/KeyboardShortcuts";
@@ -583,6 +595,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		6B31AE322E43FF0600C4653D /* LaunchAtLogin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 6B31AE312E43FF0600C4653D /* XCRemoteSwiftPackageReference "LaunchAtLogin-Modern" */;
+			productName = LaunchAtLogin;
+		};
 		6B3437232E3B6B4F00C52D3C /* KeyboardShortcuts */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 6B3437222E3B6B4F00C52D3C /* XCRemoteSwiftPackageReference "KeyboardShortcuts" */;

--- a/QuickShelf/Views/Settings/GeneralView.swift
+++ b/QuickShelf/Views/Settings/GeneralView.swift
@@ -7,10 +7,16 @@
 
 import SwiftUI
 import KeyboardShortcuts
+import LaunchAtLogin
 
 struct GeneralView: View {
     var body: some View {
         VStack(alignment: .leading) {
+            Text("General")
+                .font(.title)
+                .padding(.bottom, 18)
+            LaunchAtLogin.Toggle()
+                .padding(.bottom, 18)
             Text("Shortcuts")
                 .font(.title)
                 .padding(.bottom, 18)
@@ -22,7 +28,7 @@ struct GeneralView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(20)
-        .frame(height: 120)
+        .frame(height: 240)
     }
 }
 


### PR DESCRIPTION
This pull request integrates the `LaunchAtLogin-Modern` Swift package into the project and adds a new launch-at-login toggle to the app's general settings. The most important changes are the addition and configuration of the new package dependency and the corresponding UI update in the settings view.

#43 

**Dependency Integration:**

* Added `LaunchAtLogin-Modern` as a Swift package dependency in `QuickShelf.xcodeproj/project.pbxproj`, including the package reference, product dependency, and build phase entry. [[1]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caR571-R578) [[2]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caR598-R602) [[3]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caR213) [[4]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caR126) [[5]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caR61) [[6]](diffhunk://#diff-0ad44e70112c864f985a1500dc6da96e305cd982a9726ce0901fa865ecc1e1caR10)

**UI Update:**

* Imported `LaunchAtLogin` and added `LaunchAtLogin.Toggle()` to the `GeneralView` in `QuickShelf/Views/Settings/GeneralView.swift`, allowing users to enable or disable launching the app at login from the settings.
* Increased the height of the `GeneralView` frame to accommodate the new toggle UI element.