### PR TITLE
Add multiple selection support to shelf items list

### DIFF
--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
 
     @State private var inputDir = ""
     @State private var items: [ShelfItem] = []
+    @State private var selection = Set<URL>()
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -28,11 +29,12 @@ struct ContentView: View {
             }
             Text("Items")
                 .font(.title3)
-            List {
+            List(selection: $selection) {
                 ForEach(items.standardSorted(), id: \.url) { item in
                     ShelfItemView(item: item)
                         .alignmentGuide(.listRowSeparatorLeading) { _ in  0 }
                         .listRowSeparatorTint(Color.white.opacity(0.3))
+                        .tag(item.url)
                         .draggable(item)
                 }
             }
@@ -54,6 +56,7 @@ struct ContentView: View {
         }
         .padding(.all, 18)
         .onAppear {
+            selection = []
             if let data = UserDefaults.standard.data(forKey: "user_selected_dir") {
                 var stale = false
                 if let url = try? URL(resolvingBookmarkData: data,


### PR DESCRIPTION
This pull request updates the item list in `ContentView` to support selection, enabling users to select multiple shelf items. The changes introduce a new state property to track selected items and update the list view to bind to this selection.

Issue: #47 

**Selection functionality improvements:**

* Added a new `@State` property called `selection` to track the set of selected item URLs in `ContentView`.
* Updated the `List` view to bind its selection to the new `selection` property, allowing interactive selection of items.
* Ensured each `ShelfItemView` in the list is tagged with its URL to support selection tracking.
* Reset the `selection` state to an empty set when the view appears, ensuring no items are pre-selected.