### PR TITLE
Enable preview display of selected files

### DIFF
--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import QuickLook
 
 struct ContentView: View {
     @Environment(\.openSettings) private var openSettings
@@ -13,6 +14,7 @@ struct ContentView: View {
     @State private var inputDir = ""
     @State private var items: [ShelfItem] = []
     @State private var selection = Set<URL>()
+    @State private var previewUrl: URL?
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -31,7 +33,11 @@ struct ContentView: View {
                 .font(.title3)
             List(selection: $selection) {
                 ForEach(items.standardSorted(), id: \.url) { item in
-                    ShelfItemView(item: item)
+                    ShelfItemView(
+                        item: item,
+                        isSelected: selection.contains(item.url),
+                        onPreview: { url in previewUrl = url }
+                    )
                         .alignmentGuide(.listRowSeparatorLeading) { _ in  0 }
                         .listRowSeparatorTint(Color.white.opacity(0.3))
                         .tag(item.url)
@@ -68,6 +74,7 @@ struct ContentView: View {
                 }
             }
         }
+        .quickLookPreview($previewUrl)
     }
 
     private func openPanel() {

--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -36,7 +36,12 @@ struct ContentView: View {
                     ShelfItemView(
                         item: item,
                         isSelected: selection.contains(item.url),
-                        onPreview: { url in previewUrl = url }
+                        onPreview: { url in
+                            if let anchor = NSApp.keyWindow {
+                                SlidePanelPreview.shared.show(url: url, beside: anchor,
+                                                               size: NSSize(width: 380, height: 300))
+                            }
+                        }
                     )
                         .alignmentGuide(.listRowSeparatorLeading) { _ in  0 }
                         .listRowSeparatorTint(Color.white.opacity(0.3))
@@ -74,7 +79,9 @@ struct ContentView: View {
                 }
             }
         }
-        .quickLookPreview($previewUrl)
+        .onDisappear {
+            SlidePanelPreview.shared.hide()
+        }
     }
 
     private func openPanel() {

--- a/QuickShelf/Views/Preview/SidePanelPreview.swift
+++ b/QuickShelf/Views/Preview/SidePanelPreview.swift
@@ -1,0 +1,83 @@
+//
+//  SidePanelPreview.swift
+//  QuickShelf
+//
+//  Created by slowhand on 2025/08/26.
+//
+
+import AppKit
+import QuickLookUI
+import Carbon.HIToolbox
+
+final class SlidePanelPreview: NSObject {
+    static let shared = SlidePanelPreview()
+
+    private var panel: NSPanel?
+    private var previewView: QLPreviewView?
+    private weak var anchorWindow: NSWindow?
+    private var closeEvent: Any?
+
+    func show(url: URL, beside anchor: NSWindow, size: NSSize = NSSize(width: 360, height: 300)) {
+        anchorWindow = anchor
+        let panel = self.panel == nil ? makePanel(size: size) : self.panel!
+        if self.panel == nil { self.panel = panel }
+
+        ensurePreviewViewAlive()
+        previewView?.previewItem = url as NSURL
+        positionPanelBesideAnchor(panel: panel, anchor: anchor, size: size)
+
+        // nonactivating
+        panel.orderFrontRegardless()
+
+        // Close with the ESC key
+        if closeEvent == nil {
+            closeEvent = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+                if Int(event.keyCode) == kVK_Escape {
+                    self?.panel?.orderOut(nil)
+                    return nil
+                }
+                return event
+            }
+        }
+    }
+
+    func hide() {
+        panel?.orderOut(nil)
+    }
+
+    private func makePanel(size: NSSize) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.nonactivatingPanel, .titled, .closable, .hudWindow],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.hidesOnDeactivate = false
+        panel.hasShadow = true
+        panel.level = .floating
+        panel.collectionBehavior = [.moveToActiveSpace, .transient]
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.becomesKeyOnlyIfNeeded = true
+        return panel
+    }
+
+    private func ensurePreviewViewAlive() {
+        if previewView == nil || (previewView?.window == nil && panel?.contentView == nil) {
+            let ql = QLPreviewView(frame: .zero, style: .normal)
+            ql?.autostarts = true
+            ql?.shouldCloseWithWindow = false
+            panel?.contentView = ql
+            previewView = ql
+        }
+    }
+
+    private func positionPanelBesideAnchor(panel: NSPanel, anchor: NSWindow, size: NSSize) {
+        let anchorFrame = anchor.frame
+        let origin = NSPoint(x: anchorFrame.maxX + 8,
+                             y: anchorFrame.minY)
+        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+    }
+}
+

--- a/QuickShelf/Views/ShelfItemView.swift
+++ b/QuickShelf/Views/ShelfItemView.swift
@@ -11,6 +11,8 @@ struct ShelfItemView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     let item: ShelfItem
+    let isSelected: Bool
+    let onPreview: (URL) -> Void
 
     var body: some View {
         HStack {
@@ -29,21 +31,39 @@ struct ShelfItemView: View {
             }
             Text(item.url.lastPathComponent)
                 .foregroundColor(colorScheme == .dark ? .primary : .white.opacity(0.7))
+
+            if isSelected && !item.isDirectory {
+                Button {
+                    onPreview(item.url)
+                } label: {
+                    Image(systemName: "eye")
+                }
+                .help("Preview")
+                .buttonStyle(.borderless)
+                .keyboardShortcut(.space, modifiers: [])
+            }
         }
         .padding(.all, 8)
     }
 }
 
 #Preview("file") {
-    ShelfItemView(item: ShelfItem(
-        url: URL(filePath: "/path/to/fileName.txt")!,
-        isDirectory: false
-    ))
+    ShelfItemView(
+        item: ShelfItem(
+            url: URL(filePath: "/path/to/fileName.txt")!,
+            isDirectory: false
+        ),
+        isSelected: false,
+        onPreview: { url in print("Previewing: \(url)")}
+    )
 }
 
 #Preview("directory") {
-    ShelfItemView(item: ShelfItem(
-        url: URL(filePath: "/path/to/folderName")!,
-        isDirectory: true
-    ))
+    ShelfItemView(
+        item: ShelfItem(
+            url: URL(filePath: "/path/to/folderName")!,
+            isDirectory: true
+        ),
+        isSelected: false,
+        onPreview: { url in print("Previewing: \(url)")})
 }

--- a/QuickShelf/Views/ShelfItemView.swift
+++ b/QuickShelf/Views/ShelfItemView.swift
@@ -31,7 +31,7 @@ struct ShelfItemView: View {
             }
             Text(item.url.lastPathComponent)
                 .foregroundColor(colorScheme == .dark ? .primary : .white.opacity(0.7))
-
+            Spacer()
             if isSelected && !item.isDirectory {
                 Button {
                     onPreview(item.url)


### PR DESCRIPTION
This pull request adds a file preview feature to the QuickShelf app, allowing users to preview non-directory files in a floating side panel when they are selected. The implementation introduces a new `SlidePanelPreview` class for managing the preview panel and updates the UI to include a preview button for eligible items.

Issue: #49 

**Preview feature integration:**

* Added the `SlidePanelPreview` singleton class in `QuickShelf/Views/Preview/SidePanelPreview.swift` to display file previews in a floating panel beside the main window, including ESC key handling to close the panel.
* Updated `ContentView.swift` to pass an `onPreview` callback to `ShelfItemView`, which triggers the preview panel for selected files, and ensures the panel is hidden when the view disappears. [[1]](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efL34-R45) [[2]](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efR82-R84)

**UI enhancements for file selection and preview:**

* Modified `ShelfItemView` to accept `isSelected` and `onPreview` parameters, displaying an "eye" button for previewing non-directory items when selected, with support for spacebar keyboard shortcut. [[1]](diffhunk://#diff-d31706f20337c2436e5499efda0dd2abffe37527ac0a89f27c43d0aa79c59f1cR14-R15) [[2]](diffhunk://#diff-d31706f20337c2436e5499efda0dd2abffe37527ac0a89f27c43d0aa79c59f1cR34-R68)

**Framework imports for preview functionality:**

* Imported `QuickLook` in `ContentView.swift` to enable file preview capabilities.