### PR TITLE
Add create release github actions workflow

### DIFF
--- a/.github/workflows/create-release-with-artifact.yml
+++ b/.github/workflows/create-release-with-artifact.yml
@@ -1,0 +1,94 @@
+name: build-macos
+on:
+  push:
+    # Not used once the Drop is rejected in the released binary for some reason.
+    # tags: ["v*"]
+    branches:
+      - check/ci
+
+permissions:
+  contents: write
+
+jobs:
+  build-sign-notarize:
+    runs-on: macos-15
+
+    steps:
+    - uses: actions/checkout@v4
+
+    # Import certificates into Keychain
+    - uses: apple-actions/import-codesign-certs@v3
+      with:
+        p12-file-base64: ${{ secrets.DEV_ID_CERT_P12 }}
+        p12-password:    ${{ secrets.DEV_ID_CERT_PASSWORD }}
+
+    #  Xcode build (signed)
+    - name: Build release
+      run: |
+        xcodebuild -project QuickShelf.xcodeproj \
+                   -scheme QuickShelf \
+                   -config Release \
+                   -archivePath build/QuickShelf.xcarchive \
+                   clean archive \
+                   ARCHS="arm64 x86_64" \
+                   ONLY_ACTIVE_ARCH=NO
+      env:
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+
+    - name: Codesign
+      run: |
+        xcrun codesign --force --deep \
+          --timestamp \
+          --options runtime \
+          --entitlements QuickShelf/QuickShelf.entitlements \
+          --sign "$SIGN_ID" "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
+      env:
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+        SIGN_ID: ${{ secrets.DEVID_COMMON_NAME }}
+    # ZIP the .app
+    - name: Zip app
+      run: |
+        ditto -c -k --keepParent "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app" QuickShelf.zip
+
+    # Submit with notarytool (save Keychain profile on the fly)
+    - name: Store notary credentials
+      run: |
+        xcrun notarytool store-credentials "notary-profile" \
+          --apple-id "$APPLE_ID" \
+          --team-id "$TEAM_ID" \
+          --password "$APPLE_PASS"
+      env:
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APPLE_PASS: ${{ secrets.APPLE_PASS }}
+        TEAM_ID: ${{ secrets.TEAM_ID }}
+
+    - name: Submit to notarization
+      run: |
+        xcrun notarytool submit QuickShelf.zip \
+          --keychain-profile "notary-profile" --wait
+
+    # Staple
+    - name: Staple ticket
+      run: xcrun stapler staple "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
+
+    # Gatekeeper verification and re-zipping
+    - name: Validate
+      run: |
+        spctl --assess --type execute --verbose=4 "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
+        xcrun stapler validate "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
+        ditto -c -k --keepParent "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app" QuickShelf.zip
+
+    # - name: Create Release and Upload Assets
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   uses: softprops/action-gh-release@v2
+    #   with:
+    #     files: QuickShelf.zip
+    #     draft: true
+    #     generate_release_notes: true
+
+    # Upload Deliverables
+    - uses: actions/upload-artifact@v4
+      with:
+        name: QuickShelf-macOS
+        path: QuickShelf.zip

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,94 +1,19 @@
-name: build-macos
+name: create-release
+
 on:
   push:
-    # Not used once the Drop is rejected in the released binary for some reason.
-    # tags: ["v*"]
-    branches:
-      - check/ci
-
-permissions:
-  contents: write
+    tags: ["v*"]
 
 jobs:
-  build-sign-notarize:
-    runs-on: macos-15
-
+  build:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-
-    # Import certificates into Keychain
-    - uses: apple-actions/import-codesign-certs@v3
-      with:
-        p12-file-base64: ${{ secrets.DEV_ID_CERT_P12 }}
-        p12-password:    ${{ secrets.DEV_ID_CERT_PASSWORD }}
-
-    #  Xcode build (signed)
-    - name: Build release
-      run: |
-        xcodebuild -project QuickShelf.xcodeproj \
-                   -scheme QuickShelf \
-                   -config Release \
-                   -archivePath build/QuickShelf.xcarchive \
-                   clean archive \
-                   ARCHS="arm64 x86_64" \
-                   ONLY_ACTIVE_ARCH=NO
-      env:
-        TEAM_ID: ${{ secrets.TEAM_ID }}
-
-    - name: Codesign
-      run: |
-        xcrun codesign --force --deep \
-          --timestamp \
-          --options runtime \
-          --entitlements QuickShelf/QuickShelf.entitlements \
-          --sign "$SIGN_ID" "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
-      env:
-        TEAM_ID: ${{ secrets.TEAM_ID }}
-        SIGN_ID: ${{ secrets.DEVID_COMMON_NAME }}
-    # ZIP the .app
-    - name: Zip app
-      run: |
-        ditto -c -k --keepParent "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app" QuickShelf.zip
-
-    # Submit with notarytool (save Keychain profile on the fly)
-    - name: Store notary credentials
-      run: |
-        xcrun notarytool store-credentials "notary-profile" \
-          --apple-id "$APPLE_ID" \
-          --team-id "$TEAM_ID" \
-          --password "$APPLE_PASS"
-      env:
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_PASS: ${{ secrets.APPLE_PASS }}
-        TEAM_ID: ${{ secrets.TEAM_ID }}
-
-    - name: Submit to notarization
-      run: |
-        xcrun notarytool submit QuickShelf.zip \
-          --keychain-profile "notary-profile" --wait
-
-    # Staple
-    - name: Staple ticket
-      run: xcrun stapler staple "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
-
-    # Gatekeeper verification and re-zipping
-    - name: Validate
-      run: |
-        spctl --assess --type execute --verbose=4 "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
-        xcrun stapler validate "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app"
-        ditto -c -k --keepParent "build/QuickShelf.xcarchive/Products/Applications/QuickShelf.app" QuickShelf.zip
-
-    # - name: Create Release and Upload Assets
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   uses: softprops/action-gh-release@v2
-    #   with:
-    #     files: QuickShelf.zip
-    #     draft: true
-    #     generate_release_notes: true
-
-    # Upload Deliverables
-    - uses: actions/upload-artifact@v4
-      with:
-        name: QuickShelf-macOS
-        path: QuickShelf.zip
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Create draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          generate_release_notes: true


### PR DESCRIPTION
This pull request restructures the GitHub Actions workflows for building and releasing the project. The main change is splitting the macOS-specific build, sign, notarize, and artifact upload steps into a dedicated workflow, while simplifying the general release workflow for tagged pushes. This improves maintainability and clarity by separating platform-specific logic from the generic release process.

**Workflow restructuring:**

* Created a new workflow file `create-release-with-artifact.yml` to handle the macOS build, codesigning, notarization, and artifact upload steps, which were previously part of the main release workflow.
* Simplified the original `create-release.yml` workflow to only trigger on tagged pushes and create a draft release using the `softprops/action-gh-release` action, now running on Ubuntu instead of macOS.

**Platform-specific build logic:**

* Moved all macOS-specific steps (Xcode build, codesigning, notarization, stapling, and validation) into the new workflow, making the release process more modular and easier to manage.

**Artifact handling:**

* The new workflow now uploads the built and notarized macOS application as an artifact named `QuickShelf-macOS`.

**Release creation:**

* The main release workflow now focuses solely on creating draft releases with generated release notes for tagged commits, removing platform-specific build and signing logic.