### PR TITLE
Allow the preview display position to be set to either the left or right side

### DIFF
--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -10,6 +10,10 @@ import QuickLook
 
 struct ContentView: View {
     @Environment(\.openSettings) private var openSettings
+    @AppStorage("preview.side")
+    private var sideRaw: String = PreviewSide.right.rawValue
+
+    private var side: PreviewSide { PreviewSide(rawValue: sideRaw) ?? .right }
 
     @State private var inputDir = ""
     @State private var items: [ShelfItem] = []
@@ -38,7 +42,7 @@ struct ContentView: View {
                         isSelected: selection.contains(item.url),
                         onPreview: { url in
                             if let anchor = NSApp.keyWindow {
-                                SlidePanelPreview.shared.show(url: url, beside: anchor,
+                                SlidePanelPreview.shared.show(url: url, beside: anchor, side: side,
                                                                size: NSSize(width: 380, height: 300))
                             }
                         }

--- a/QuickShelf/Views/Preview/SidePanelPreview.swift
+++ b/QuickShelf/Views/Preview/SidePanelPreview.swift
@@ -17,14 +17,19 @@ final class SlidePanelPreview: NSObject {
     private weak var anchorWindow: NSWindow?
     private var closeEvent: Any?
 
-    func show(url: URL, beside anchor: NSWindow, size: NSSize = NSSize(width: 360, height: 300)) {
+    func show(
+        url: URL,
+        beside anchor: NSWindow,
+        side: PreviewSide,
+        size: NSSize = NSSize(width: 360, height: 300)
+    ) {
         anchorWindow = anchor
         let panel = self.panel == nil ? makePanel(size: size) : self.panel!
         if self.panel == nil { self.panel = panel }
 
         ensurePreviewViewAlive()
         previewView?.previewItem = url as NSURL
-        positionPanelBesideAnchor(panel: panel, anchor: anchor, size: size)
+        positionPanelBesideAnchor(panel: panel, anchor: anchor, side: side, size: size)
 
         // nonactivating
         panel.orderFrontRegardless()
@@ -73,15 +78,14 @@ final class SlidePanelPreview: NSObject {
         }
     }
 
-    private func positionPanelBesideAnchor(panel: NSPanel, anchor: NSWindow, size: NSSize) {
+    private func positionPanelBesideAnchor(panel: NSPanel, anchor: NSWindow, side: PreviewSide, size: NSSize) {
         let anchorFrame = anchor.frame
         let screen = anchor.screen ?? NSScreen.main
         let visibleFrame = screen?.visibleFrame ?? .infinite
 
         var origin = NSPoint(x: anchorFrame.maxX + 8,
                              y: anchorFrame.minY)
-        // TODO: Make it switchable in the settings
-        if true {
+        if side == .left {
             var x = anchorFrame.minX - 8 - size.width
             var y = anchorFrame.minY
 

--- a/QuickShelf/Views/Preview/SidePanelPreview.swift
+++ b/QuickShelf/Views/Preview/SidePanelPreview.swift
@@ -75,9 +75,21 @@ final class SlidePanelPreview: NSObject {
 
     private func positionPanelBesideAnchor(panel: NSPanel, anchor: NSWindow, size: NSSize) {
         let anchorFrame = anchor.frame
-        let origin = NSPoint(x: anchorFrame.maxX + 8,
+        let screen = anchor.screen ?? NSScreen.main
+        let visibleFrame = screen?.visibleFrame ?? .infinite
+
+        var origin = NSPoint(x: anchorFrame.maxX + 8,
                              y: anchorFrame.minY)
-        panel.setFrame(NSRect(origin: origin, size: size), display: true)
+        // TODO: Make it switchable in the settings
+        if true {
+            var x = anchorFrame.minX - 8 - size.width
+            var y = anchorFrame.minY
+
+            y = max(min(y, visibleFrame.maxY - size.height), visibleFrame.minY)
+            if x < visibleFrame.minX { x = visibleFrame.minX }
+            origin = NSPoint(x: x, y: y)
+        }
+        panel.setFrame(NSRect(origin: origin, size: size), display: true, animate: true)
     }
 }
 

--- a/QuickShelf/Views/Settings/GeneralView.swift
+++ b/QuickShelf/Views/Settings/GeneralView.swift
@@ -9,14 +9,32 @@ import SwiftUI
 import KeyboardShortcuts
 import LaunchAtLogin
 
+enum PreviewSide: String, CaseIterable, Identifiable {
+    case left, right
+    var id: String { rawValue }
+}
+
 struct GeneralView: View {
+    @AppStorage("preview.side")
+    private var sideRaw: String = PreviewSide.right.rawValue
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("General")
                 .font(.title)
                 .padding(.bottom, 18)
             LaunchAtLogin.Toggle()
-                .padding(.bottom, 18)
+                .padding(.bottom, 8)
+            Picker("Preview position", selection: Binding(
+                get: { PreviewSide(rawValue: sideRaw) ?? .right },
+                set: { sideRaw = $0.rawValue }
+            )) {
+                Text("Left").tag(PreviewSide.left)
+                Text("Right").tag(PreviewSide.right)
+            }
+            .pickerStyle(.menu)
+            .fixedSize()
+            .padding(.bottom, 18)
             Text("Shortcuts")
                 .font(.title)
                 .padding(.bottom, 18)


### PR DESCRIPTION
This pull request introduces a new user preference for controlling the position of the preview panel (left or right side of the main window), and updates the preview logic to respect this setting. The most important changes are grouped below:

Issue: #56 

**User Preference Addition:**

* Added a new `PreviewSide` enum and a corresponding `@AppStorage` property to persist the user's choice for preview panel position (`left` or `right`). The setting is surfaced in the `GeneralView` as a menu picker for "Preview position".

**Preview Panel Logic Updates:**

* Updated `ContentView` to read the preview side preference and pass it to the preview logic when showing an item. [[1]](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efR13-R16) [[2]](diffhunk://#diff-af7a582a2031f2cd568c19ff7ca03b7747b9d07abbf90b594ca61bfee9b2f2efL41-R45)
* Modified `SlidePanelPreview.show` to accept the `side` parameter and forward it to the positioning logic.
* Enhanced `positionPanelBesideAnchor` to position the preview panel on either the left or right of the anchor window, respecting screen bounds and the user’s preference.