### PR TITLE
✨ Add inline rename functionality with context menu and error handling

### DIFF
--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -56,6 +56,7 @@ struct ContentView: View {
                         ShelfItemView(
                             item: item,
                             isSelected: selection.contains(item.url),
+                            isMultiSelected: selection.count != 1,
                             onPreview: { url in
                                 if let anchor = NSApp.keyWindow {
                                     SlidePanelPreview.shared.show(
@@ -63,16 +64,13 @@ struct ContentView: View {
                                         size: NSSize(width: 380, height: 300)
                                     )
                                 }
-                            }
+                            },
+                            onEdit: { startInlineRename() }
                         )
                         .alignmentGuide(.listRowSeparatorLeading) { _ in 0 }
                         .listRowSeparatorTint(Color.white.opacity(0.3))
                         .tag(item.url)
                         .draggable(item)
-                        .contextMenu {
-                            Button("Rename…") { startInlineRename() }
-                                .disabled(selection.count != 1)
-                        }
                     }
                 }
             }
@@ -107,15 +105,6 @@ struct ContentView: View {
             }
         }
         .onDisappear { SlidePanelPreview.shared.hide() }
-
-        // Press Enter to begin editing (only when one item is selected and not currently being edited)
-        .overlay(
-            Button(action: startInlineRename) { EmptyView() }
-                .keyboardShortcut(.return, modifiers: [])
-                .disabled(!(selection.count == 1 && editingUrl == nil))
-                .frame(width: 0, height: 0)
-                .opacity(0)
-        )
         .overlay(alignment: .bottom) {
             if let msg = errorMessage {
                 ErrorBannerView(message: msg) {

--- a/QuickShelf/ContentView.swift
+++ b/QuickShelf/ContentView.swift
@@ -148,8 +148,7 @@ struct ContentView: View {
         let dest = dir.appendingPathComponent(newName)
 
         if FileManager.default.fileExists(atPath: dest.path) {
-            NSSound.beep()
-            withAnimation { errorMessage = "A file named “\(newName)” already exists." }
+            cancelRename();
             return
         }
         do {

--- a/QuickShelf/Views/ErrorBannerView.swift
+++ b/QuickShelf/Views/ErrorBannerView.swift
@@ -1,0 +1,52 @@
+//
+//  ErrorBannerView.swift
+//  QuickShelf
+//
+//  Created by slowhand on 2025/09/04.
+//
+
+import SwiftUI
+
+struct ErrorBannerView: View {
+    @State private var autoHideTaskID = UUID()
+
+    let message: String
+    var onClose: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+            Text(message)
+                .lineLimit(2)
+                .truncationMode(.tail)
+            Spacer()
+            Button {
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(.regularMaterial)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(.red.opacity(0.6), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .padding(.horizontal, 8)
+        .task(id: message) {
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
+            await MainActor.run { onClose() }
+        }
+    }
+}
+
+#Preview {
+    ErrorBannerView(
+        message: "message",
+        onClose: {}
+    )
+}

--- a/QuickShelf/Views/ShelfItemEditView.swift
+++ b/QuickShelf/Views/ShelfItemEditView.swift
@@ -1,0 +1,56 @@
+//
+//  ShelfItemEditView.swift
+//  QuickShelf
+//
+//  Created by slowhand on 2025/09/04.
+//
+
+import SwiftUI
+
+struct ShelfItemEditView: View {
+    let item: ShelfItem
+    @Binding var text: String
+    var onCommit: () -> Void
+    var onCancel: () -> Void
+
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        HStack {
+            if item.isDirectory {
+                Image(systemName: "folder")
+            } else {
+                if ProcessInfo.isPreview {
+                    Image(systemName: "text.page")
+                } else {
+                    Image(nsImage: NSWorkspace.shared.icon(forFile: item.url.path))
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 20, height: 20)
+                }
+            }
+
+            TextField("New name", text: $text, onCommit: onCommit)
+                .textFieldStyle(.roundedBorder)
+                .focused($focused)
+                .onAppear { focused = true }
+
+            Spacer()
+        }
+        .padding(.all, 8)
+        .onExitCommand { onCancel() }
+    }
+}
+
+#Preview {
+    @Previewable @State var text = ""
+    ShelfItemEditView(
+        item: ShelfItem(
+            url: URL(filePath: "/path/to/fileName.txt")!,
+            isDirectory: false
+        ),
+        text: $text,
+        onCommit: {},
+        onCancel: {}
+    )
+}

--- a/QuickShelf/Views/ShelfItemView.swift
+++ b/QuickShelf/Views/ShelfItemView.swift
@@ -12,7 +12,9 @@ struct ShelfItemView: View {
 
     let item: ShelfItem
     let isSelected: Bool
+    let isMultiSelected: Bool
     let onPreview: (URL) -> Void
+    let onEdit: () -> Void
 
     var body: some View {
         HStack {
@@ -32,15 +34,24 @@ struct ShelfItemView: View {
             Text(item.url.lastPathComponent)
                 .foregroundColor(colorScheme == .dark ? .primary : .white.opacity(0.7))
             Spacer()
-            if isSelected && !item.isDirectory {
+            if isSelected && !isMultiSelected {
                 Button {
                     onPreview(item.url)
                 } label: {
                     Image(systemName: "eye")
                 }
-                .help("Preview")
-                .buttonStyle(.borderless)
-                .keyboardShortcut(.space, modifiers: [])
+                    .help("Preview")
+                    .buttonStyle(.borderless)
+                    .keyboardShortcut(.space, modifiers: [])
+                    .opacity(!item.isDirectory ? 1 : 0)
+                Button {
+                    onEdit()
+                } label: {
+                    Image(systemName: "pencil")
+                }
+                    .help("Rename")
+                    .buttonStyle(.borderless)
+                    .keyboardShortcut(.return, modifiers: [])
             }
         }
         .padding(.all, 8)
@@ -54,7 +65,9 @@ struct ShelfItemView: View {
             isDirectory: false
         ),
         isSelected: false,
-        onPreview: { url in print("Previewing: \(url)")}
+        isMultiSelected: false,
+        onPreview: { url in print("Previewing: \(url)")},
+        onEdit: {}
     )
 }
 
@@ -65,5 +78,8 @@ struct ShelfItemView: View {
             isDirectory: true
         ),
         isSelected: false,
-        onPreview: { url in print("Previewing: \(url)")})
+        isMultiSelected: false,
+        onPreview: { url in print("Previewing: \(url)")},
+        onEdit: {}
+    )
 }


### PR DESCRIPTION
Description

This pull request adds inline rename functionality for items in the shelf, improves error feedback to users, and refines the item preview and selection logic. The main changes introduce a new edit mode for shelf items, an error banner for rename failures, and UI updates to support these features.

## Changes

- [x] Feature / Enhancement
- [ ] Bug fix
- [ ] Documentation update
- [ ] Other (please describe):

## How to Test

Steps to manually test this pull request:
1.  Open the shelf
2.  Press the Enter key or click the edit icon

## Screenshots (if applicable)

Add screenshots of the changes/fixes if they help reviewers understand.

## Related Issues

